### PR TITLE
remove unused mutex

### DIFF
--- a/leveldb/memdb/bench_test.go
+++ b/leveldb/memdb/bench_test.go
@@ -9,7 +9,6 @@ package memdb
 import (
 	"encoding/binary"
 	"math/rand"
-	"sync"
 	"testing"
 
 	"github.com/pingcap/goleveldb/leveldb/comparer"
@@ -26,28 +25,6 @@ func BenchmarkPut(b *testing.B) {
 	for i := range buf {
 		p.Put(buf[i][:], nil)
 	}
-}
-
-func BenchmarkConcurrentPut(b *testing.B) {
-	buf := make([][4]byte, b.N)
-	for i := range buf {
-		binary.LittleEndian.PutUint32(buf[i][:], uint32(i))
-	}
-
-	b.ResetTimer()
-	var wg sync.WaitGroup
-	wg.Add(100)
-	for i := 0; i < 100; i++ {
-		go func() {
-			db := New(comparer.DefaultComparer, 0)
-			for i := 0; i < len(buf); i++ {
-				db.Put(buf[i][:], nil)
-			}
-			db.Free()
-			wg.Done()
-		}()
-	}
-	wg.Wait()
 }
 
 func BenchmarkPutRandom(b *testing.B) {

--- a/leveldb/memdb/memdb_suite_test.go
+++ b/leveldb/memdb/memdb_suite_test.go
@@ -2,36 +2,14 @@ package memdb
 
 import (
 	"math/rand"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/pingcap/goleveldb/leveldb/comparer"
 	"github.com/pingcap/goleveldb/leveldb/testutil"
 )
 
 func TestMemDB(t *testing.T) {
 	testutil.RunSuite(t, "MemDB Suite")
-}
-
-func TestRace(t *testing.T) {
-	var wg sync.WaitGroup
-	db := New(comparer.DefaultComparer, 0)
-
-	for i := 0; i < 5000; i++ {
-		wg.Add(1)
-		go func(db *DB, wg *sync.WaitGroup) {
-			defer wg.Done()
-
-			for i := 0; i < 2000; i++ {
-				if db.rnd.src.Int63()%5 == 0 {
-					db.rnd.src.Seed(db.rnd.src.Int63())
-				}
-			}
-
-		}(db, &wg)
-	}
-	wg.Wait()
 }
 
 func TestBitRand(t *testing.T) {

--- a/leveldb/memdb/memdb_test.go
+++ b/leveldb/memdb/memdb_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func (p *DB) TestFindLT(key []byte) (rkey, value []byte, err error) {
-	p.mu.RLock()
 	if node := p.findLT(key); node != 0 {
 		n := p.nodeData[node]
 		m := n + p.nodeData[node+nKey]
@@ -26,12 +25,10 @@ func (p *DB) TestFindLT(key []byte) (rkey, value []byte, err error) {
 	} else {
 		err = ErrNotFound
 	}
-	p.mu.RUnlock()
 	return
 }
 
 func (p *DB) TestFindLast() (rkey, value []byte, err error) {
-	p.mu.RLock()
 	if node := p.findLast(); node != 0 {
 		n := p.nodeData[node]
 		m := n + p.nodeData[node+nKey]
@@ -40,7 +37,6 @@ func (p *DB) TestFindLast() (rkey, value []byte, err error) {
 	} else {
 		err = ErrNotFound
 	}
-	p.mu.RUnlock()
 	return
 }
 


### PR DESCRIPTION
Currently, the only component of goleveldb that tidb depends on is memdb, and tidb is using it in a single thread/goroutine, there is no need to use mutex. Not sure if i am right. 

Here is the benchmark:

with mutex:
BenchmarkPut-12              	       961 ns/op
BenchmarkPutRandom-12            1506 ns/op
BenchmarkGet-12              	       1038 ns/op
BenchmarkGetRandom-12            2009 ns/op

after removed mutex:
BenchmarkPut-12          		       891 ns/op
BenchmarkPutRandom-12    	       1516 ns/op
BenchmarkGet-12          		       993 ns/op
BenchmarkGetRandom-12    	       2017 ns/op